### PR TITLE
Update download links for caido

### DIFF
--- a/packages/pentesting/caido-cli/PKGBUILD
+++ b/packages/pentesting/caido-cli/PKGBUILD
@@ -10,8 +10,8 @@ url="https://caido.io/"
 license=('private')
 depends=(gcc-libs glibc)
 conflicts=('caido-desktop')
-source_x86_64=("$pkgname-$pkgver-x86_64.tar.gz::https://storage.googleapis.com/caido-releases/v${pkgver}/caido-cli-v${pkgver}-linux-x86_64.tar.gz")
-source_aarch64=("$pkgname-$pkgver-aarch64.tar.gz::https://storage.googleapis.com/caido-releases/v${pkgver}/caido-cli-v${pkgver}-linux-aarch64.tar.gz")
+source_x86_64=("$pkgname-$pkgver-x86_64.tar.gz::https://caido.download/releases/v${pkgver}/caido-cli-v${pkgver}-linux-x86_64.tar.gz")
+source_aarch64=("$pkgname-$pkgver-aarch64.tar.gz::https://caido.download/releases/v${pkgver}/caido-cli-v${pkgver}-linux-aarch64.tar.gz")
 sha512sums_x86_64=('c986a8a6b99838991d4ed50900e4b31038763f1b204b49b3616800233b95ea7d4ee28eeb4e2a2d226ff5012f43c4d17e481bf3d657ebc664e280d1a5185c18fa')
 sha512sums_aarch64=('97ee9c243f5d88c6b4d3a335717057603a3a0d48c45af03958d377d1cd8c5546a947874227ceeddc712de1c7b64abcd6dd59d34736b7bdddf3dc6acb35f25fc4')
 


### PR DESCRIPTION
We are moving away from GCP, this is our new download domain.
This will be officially supported now and documentation is available at https://docs.caido.io/concepts/internals/download.html