### PR TITLE
auto-update(dory): 506.eb3bf50 -> 505.c5c6a22

### DIFF
--- a/src/os-specific/system/dory/PKGBUILD
+++ b/src/os-specific/system/dory/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=dory
-pkgver=506.eb3bf50
+pkgver=505.c5c6a22
 pkgrel=1
 pkgdesc='Scriptable backend installer for Athena OS.'
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `dory` (VCS — git commit tracking)
**Previous pkgver:** `506.eb3bf50`
**New pkgver:** `505.c5c6a22`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
