### PR TITLE
auto-update(athena-settings): 5.025d097 -> 6.b6c1b6d

### DIFF
--- a/src/os-specific/system/athena-settings/PKGBUILD
+++ b/src/os-specific/system/athena-settings/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=athena-settings
 _pkgname=${pkgname#athena-}
-pkgver=5.025d097
+pkgver=6.b6c1b6d
 pkgrel=1
 pkgdesc='System configuration for Athena.'
 arch=('any')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `athena-settings` (VCS — git commit tracking)
**Previous pkgver:** `5.025d097`
**New pkgver:** `6.b6c1b6d`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
