### PR TITLE
auto-update(athena-uki): 2.76e6f37 -> 3.ca09731

### DIFF
--- a/src/os-specific/system/athena-uki/PKGBUILD
+++ b/src/os-specific/system/athena-uki/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=athena-uki
 _pkgname=${pkgname#athena-}
-pkgver=2.76e6f37
+pkgver=3.ca09731
 pkgrel=1
 pkgdesc='Unified Kernel Image builder and hooks for Athena OS.'
 arch=('any')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `athena-uki` (VCS — git commit tracking)
**Previous pkgver:** `2.76e6f37`
**New pkgver:** `3.ca09731`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
