### PR TITLE
auto-update(athena-uki): 3.ca09731 -> 4.2cc215a

### DIFF
--- a/src/os-specific/system/athena-uki/PKGBUILD
+++ b/src/os-specific/system/athena-uki/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=athena-uki
 _pkgname=${pkgname#athena-}
-pkgver=3.ca09731
+pkgver=4.2cc215a
 pkgrel=1
 pkgdesc='Unified Kernel Image builder and hooks for Athena OS.'
 arch=('any')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `athena-uki` (VCS — git commit tracking)
**Previous pkgver:** `3.ca09731`
**New pkgver:** `4.2cc215a`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
