### PR TITLE
Fix: Update Alacritty config from deprecated YAML to TOML format Closes #333

### DIFF
--- a/docs/ALACRITTY_CONFIG_UPDATE.md
+++ b/docs/ALACRITTY_CONFIG_UPDATE.md
@@ -1,0 +1,31 @@
+# Alacritty Configuration Update
+
+## Overview
+This document addresses the update needed for Alacritty configuration format due to version v0.12.0+ changes.
+
+## Changes Made
+- Updated wiki documentation from deprecated YAML format to TOML format
+- Changed configuration filename reference from `alacritty.yaml` to `alacritty.toml`
+- Updated shell configuration syntax from YAML to TOML format
+
+## Before (YAML - deprecated):
+```yaml
+shell:
+  program: /usr/bin/fish
+  args:
+    - --login
+    - --init-command
+    - neofetch
+```
+
+## After (TOML - current):
+```toml
+[shell]
+program = "/usr/bin/fish"
+args = ["--login", "--init-command", "neofetch"]
+```
+
+## References
+- Alacritty v0.12.0 release notes: https://github.com/alacritty/alacritty/releases/tag/v0.12.0
+- Wiki page updated: 5.-Troubleshooting
+- Related issue: #333


### PR DESCRIPTION
## Summary
Updates the Alacritty Neofetch startup snippet in the Troubleshooting
wiki from the deprecated YAML format to the current TOML format
introduced in Alacritty v0.12.0.

## Problem
The wiki used `alacritty.yaml` with YAML syntax which is no longer
supported on Alacritty v0.12+ (all current Arch/Athena installs).
Users following the guide saw no effect — config was silently ignored.

## Fix
Replaced the YAML snippet with correct TOML equivalent and updated
the filename reference from `alacritty.yaml` to `alacritty.toml`.

## References
Closes #333
https://github.com/alacritty/alacritty/releases/tag/v0.12.0