### PR TITLE
auto-update(htb-toolkit): 85.7c95202 -> 86.d94546d

### DIFF
--- a/src/os-specific/applications/htb-toolkit/PKGBUILD
+++ b/src/os-specific/applications/htb-toolkit/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=htb-toolkit
-pkgver=85.7c95202
+pkgver=86.d94546d
 pkgrel=1
 pkgdesc='Play Hack The Box machines directly on your system.'
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `htb-toolkit` (VCS — git commit tracking)
**Previous pkgver:** `85.7c95202`
**New pkgver:** `86.d94546d`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
