### PR TITLE
auto-update(cyber-toolkit): 44.7e12176 -> 46.f6874b0

### DIFF
--- a/src/os-specific/applications/cyber-toolkit/PKGBUILD
+++ b/src/os-specific/applications/cyber-toolkit/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=cyber-toolkit
-pkgver=44.7e12176
+pkgver=46.f6874b0
 pkgrel=1
 pkgdesc='Set your Cyber Security role.'
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `cyber-toolkit` (VCS — git commit tracking)
**Previous pkgver:** `44.7e12176`
**New pkgver:** `46.f6874b0`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
