### PR TITLE
auto-update(athena-nexus): 6.5554727 -> 8.ac2171c

### DIFF
--- a/src/os-specific/applications/athena-nexus/PKGBUILD
+++ b/src/os-specific/applications/athena-nexus/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=athena-nexus
-pkgver=6.5554727
+pkgver=8.ac2171c
 pkgrel=1
 pkgdesc="Deploy and manage cybersecurity tools as containers."
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `athena-nexus` (VCS — git commit tracking)
**Previous pkgver:** `6.5554727`
**New pkgver:** `8.ac2171c`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
