### PR TITLE
auto-update(dory): 519.36ee4c2 -> 520.3ef0485

### DIFF
--- a/src/os-specific/system/dory/PKGBUILD
+++ b/src/os-specific/system/dory/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=dory
-pkgver=519.36ee4c2
+pkgver=520.3ef0485
 pkgrel=1
 pkgdesc='Scriptable backend installer for Athena OS.'
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `dory` (VCS — git commit tracking)
**Previous pkgver:** `519.36ee4c2`
**New pkgver:** `520.3ef0485`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
