### PR TITLE
auto-update(htb-toolkit): 88.c480c2c -> 89.9edd01f

### DIFF
--- a/src/os-specific/applications/htb-toolkit/PKGBUILD
+++ b/src/os-specific/applications/htb-toolkit/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=htb-toolkit
-pkgver=88.c480c2c
-pkgrel=2
+pkgver=89.9edd01f
+pkgrel=1
 pkgdesc='Play Hack The Box machines directly on your system.'
 arch=('x86_64' 'aarch64')
 url='https://github.com/Athena-OS/htb-toolkit'


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `htb-toolkit` (VCS — git commit tracking)
**Previous pkgver:** `88.c480c2c`
**New pkgver:** `89.9edd01f`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
