### PR TITLE
auto-update(graphite-gtk-theme): 2025.07.06.r10.g57028b0 -> 2026.08.23.r5.g364173f

### DIFF
--- a/src/environments/design/materials/gtk/graphite-gtk-theme/PKGBUILD
+++ b/src/environments/design/materials/gtk/graphite-gtk-theme/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=graphite-gtk-theme
 _pkgname=Graphite-gtk-theme
-pkgver=2025.07.06.r10.g57028b0
+pkgver=2026.08.23.r5.g364173f
 pkgrel=1
 pkgdesc='Graphite Dark theme.'
 arch=('any')

--- a/src/environments/design/materials/gtk/graphite-gtk-theme/PKGBUILD
+++ b/src/environments/design/materials/gtk/graphite-gtk-theme/PKGBUILD
@@ -25,8 +25,8 @@ package() {
 
   install -dm 755 "$pkgdir/usr/share/themes"
 
-  ./install.sh -n Graphite -c dark -d "$pkgdir/usr/share/themes"
-  ./install.sh -n Graphite-Rimless -c dark --tweaks rimless -d "$pkgdir/usr/share/themes"
+  DESTDIR="$pkgdir" ./install.sh -n Graphite -c dark -d "$pkgdir/usr/share/themes"
+  DESTDIR="$pkgdir" ./install.sh -n Graphite-Rimless -c dark --tweaks rimless -d "$pkgdir/usr/share/themes"
 
   rm -rf "$pkgdir/usr/share/themes/Graphite-Dark-hdpi" "$pkgdir/usr/share/themes/Graphite-Dark-xhdpi" "$pkgdir/usr/share/themes/Graphite-Rimless-Dark-hdpi" "$pkgdir/usr/share/themes/Graphite-Rimless-Dark-xhdpi"
 }


### PR DESCRIPTION
## Automated PKGBUILD update

**Package:** `graphite-gtk-theme` (VCS — git commit tracking)
**Previous pkgver:** `2025.07.06.r10.g57028b0`
**New pkgver:** `2026.08.23.r5.g364173f`
**pkgrel reset to:** 1

`pkgver` was computed by running the `pkgver()` function against the
latest upstream commit. Checksums use `SKIP` (standard for VCS packages).

Please verify before merging:
- [ ] Package builds correctly with `makepkg -si`
- [ ] No breaking changes in recent upstream commits

---
*Automatically generated by the nvchecker workflow.*
